### PR TITLE
chore: Clean up badges, go mod, and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 TheCodingMachine
+Copyright (c) 2024 dcaraxes
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**🔥 Working with Gotenberg version 8 and higher! 🔥** 
+**🔥 Working with Gotenberg version 8 and higher! 🔥**
 
 # Gotenberg Go client
 
@@ -62,6 +62,5 @@ For more complete usages, head to the [documentation](https://gotenberg.dev/).
 
 ## Badges
 
-[![Travis CI](https://travis-ci.org/thecodingmachine/gotenberg-go-client.svg?branch=master)](https://travis-ci.org/thecodingmachine/gotenberg-go-client)
-[![GoDoc](https://godoc.org/github.com/thecodingmachine/gotenberg-go-client?status.svg)](https://godoc.org/github.com/thecodingmachine/gotenberg-go-client)
-[![Go Report Card](https://goreportcard.com/badge/github.com/thecodingmachine/gotenberg-go-client)](https://goreportcard.com/report/thecodingmachine/gotenberg-go-client)
+[![GoDoc](https://godoc.org/github.com/dcaraxes/gotenberg-go-client/v8?status.svg)](https://godoc.org/github.com/dcaraxes/gotenberg-go-client/v8)
+[![Go Report Card](https://goreportcard.com/badge/github.com/dcaraxes/gotenberg-go-client/v8)](https://goreportcard.com/report/github.com/dcaraxes/gotenberg-go-client/v8)

--- a/build/tests/Dockerfile
+++ b/build/tests/Dockerfile
@@ -3,7 +3,7 @@ ARG GOTENBERG_VERSION
 
 FROM golang:${GOLANG_VERSION}-alpine AS golang
 
-FROM thecodingmachine/gotenberg:${GOTENBERG_VERSION}
+FROM gotenberg/gotenberg:${GOTENBERG_VERSION}
 
 USER root
 
@@ -13,9 +13,9 @@ USER root
 # |
 # | Libraries used in the build process of this image.
 # |
-RUN apt-get update
-RUN apt-get install -y build-essential
-RUN apt-get install manpages-dev
+RUN apt-get update \
+  && apt-get install -y build-essential \
+  && apt-get install manpages-dev
 
 # |--------------------------------------------------------------------------
 # | Golang

--- a/doc.go
+++ b/doc.go
@@ -3,6 +3,6 @@ Package gotenberg is a Go client for
 interacting with a Gotenberg API.
 
 For more complete usages, head to the documentation:
-https://thecodingmachine.github.io/gotenberg/
+https://gotenberg.dev/
 */
 package gotenberg

--- a/document.go
+++ b/document.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -69,7 +68,7 @@ func NewDocumentFromString(filename, data string) (Document, error) {
 }
 
 func (doc *documentFromString) Reader() (io.ReadCloser, error) {
-	return ioutil.NopCloser(strings.NewReader(doc.data)), nil
+	return io.NopCloser(strings.NewReader(doc.data)), nil
 }
 
 type documentFromBytes struct {
@@ -91,7 +90,7 @@ func NewDocumentFromBytes(filename string, data []byte) (Document, error) {
 }
 
 func (doc *documentFromBytes) Reader() (io.ReadCloser, error) {
-	return ioutil.NopCloser(bytes.NewReader(doc.data)), nil
+	return io.NopCloser(bytes.NewReader(doc.data)), nil
 }
 
 // Compile-time checks to ensure type implements desired interfaces.

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,7 @@ module github.com/dcaraxes/gotenberg-go-client/v8
 
 go 1.22.0
 
-require (
-	github.com/stretchr/testify v1.9.0
-)
+require github.com/stretchr/testify v1.9.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,14 +1,9 @@
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/thecodingmachine/gotenberg-go-client/v7 v7.2.0 h1:wsdZLvaHRttyvaji+0zqhDNeVXt4atA1A3XNqDkUTVo=
-github.com/thecodingmachine/gotenberg-go-client/v7 v7.2.0/go.mod h1:ABZ2YPzV+IMgtj91+DkoB8/y3qezCQvWhKnGxkY2cSs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
I notice that you're actually fixing this, so I figured I'd go ahead and clean some stuff up I noticed that's leftover from the originally forked PR.

1. Update the copyright year and name to your GitHub username (could be your name instead, wasn't sure which you wanted).
2. Fix all of the badges in the README. They were still linking to the original repo's project, which was a pain, especially for the documentation link. I also removed the travis badge, as it appears you don't have travis set up?
3. Updated the docker image in the tests Dockerfile.
4. Update the link in the `doc.go` file to match the new docs URL.
5. Replace the deprecated `ioutil.NopCloser` function, as my editor was yelling at me about it.
6. Ran `go mod tidy` to clean up the `go.mod` and `go.sum` files, as the still included the old testing library.

Feel free to cherry pick any of these changes if you don't want all of them!