### PR TITLE
feat: Add the missing flags that are available for HTML to PDF conversion

### DIFF
--- a/chrome.go
+++ b/chrome.go
@@ -20,6 +20,9 @@ const (
 	scale                      string = "scale"
 	skipNetworkIdleEvent       string = "skipNetworkIdleEvent"
 	singlePage                 string = "singlePage"
+	preferCssPageSize          string = "preferCssPageSize"
+	printBackground            string = "printBackground"
+	omitBackground             string = "omitBackground"
 	format                     string = "format"
 )
 
@@ -127,6 +130,21 @@ func (req *chromeRequest) SkipNetworkIdleEvent() {
 // SinglePage sets singlePage form field as true.
 func (req *chromeRequest) SinglePage() {
 	req.values[singlePage] = "true"
+}
+
+// Define whether to prefer page size as defined by CSS.
+func (req *chromeRequest) PreferCssPageSize() {
+	req.values[preferCssPageSize] = "true"
+}
+
+// Print the background graphics.
+func (req *chromeRequest) PrintBackground() {
+	req.values[printBackground] = "true"
+}
+
+// Omit the background graphics.
+func (req *chromeRequest) OmitBackground() {
+	req.values[omitBackground] = "true"
 }
 
 // Format sets format form field


### PR DESCRIPTION
I noticed that not all of the flags that are listed in the [Page Properties section of the gotenberg docs](https://gotenberg.dev/docs/routes#page-properties-chromium) for HTML to PDF conversion were included as options in this package. All three of these options are just booleans so I figured I'd just add them for you real quick. Hopefully this is a pretty non-controversial addition haha.

If I had to guess, these are probably new options that were added in gotenberg v8 or something, hence why they weren't included in the original options.