### PR TITLE
feat: Change sizes (paper size and margins) to structs with optional unit

### DIFF
--- a/chrome.go
+++ b/chrome.go
@@ -111,6 +111,7 @@ var (
 		Bottom: 0,
 		Left:   0,
 		Right:  0,
+		Unit:   IN,
 	}
 	// NormalMargins uses 1 inch margins.
 	NormalMargins = PageMargins{


### PR DESCRIPTION
This is the last change I was thinking could really benefit this package, however it's also the most controversial haha. Basically, all of the margin and paper size [page properties](https://gotenberg.dev/docs/routes#page-properties-chromium) accept a string with a unit at the end. If you omit the unit, it defaults to inches. This package currently only accepts inches, which are not a very precise unit relative to the others. Of course it's possible to convert from inches to whatever other unit you'd like to use, inches don't translate very nicely to metric (1 inch is 25.4 mm).

So this PR changes the `PaperSize` and `Margins` arguments to be a custom struct which accepts all of their respective dimensions as keys, as well as a `Unit` field. This way, the unit is technically still optional and will default to inches if not passed. This also removes any confusion about what order the fields are in (I keep forgetting which order the margins are in haha), as you have to name each dimension specifically.

---

Now, I do understand this is actually a significantly breaking change. I am also happy to modify this to make it pass new functions instead. Something like `PaperSizeWithUnit` and `MarginsWithUnit`. I just wanted to throw this out there as a potential alternative to what this package does now, as I generally prefer the struct approach anyway haha. But yeah, even if you don't want to implement this as a breaking change, let me know if there's any way I could get this merged in some way, even if just with new alternative functions.