### PR TITLE
feat: document from reader

### DIFF
--- a/document.go
+++ b/document.go
@@ -93,9 +93,32 @@ func (doc *documentFromBytes) Reader() (io.ReadCloser, error) {
 	return io.NopCloser(bytes.NewReader(doc.data)), nil
 }
 
+type documentFromReader struct {
+	r io.Reader
+
+	*document
+}
+
+// NewDocumentFromReader creates a Document from
+// a reader.
+func NewDocumentFromReader(filename string, r io.Reader) (Document, error) {
+	if r == nil {
+		return nil, fmt.Errorf("%s: reader is nil", filename)
+	}
+	return &documentFromReader{
+		r,
+		&document{filename},
+	}, nil
+}
+
+func (doc *documentFromReader) Reader() (io.ReadCloser, error) {
+	return io.NopCloser(doc.r), nil
+}
+
 // Compile-time checks to ensure type implements desired interfaces.
 var (
 	_ = Document(new(documentFromPath))
 	_ = Document(new(documentFromString))
 	_ = Document(new(documentFromBytes))
+	_ = Document(new(documentFromReader))
 )

--- a/html_test.go
+++ b/html_test.go
@@ -60,6 +60,23 @@ func TestHTMLFromBytes(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestHTMLFromReader(t *testing.T) {
+	c := &Client{Hostname: "http://localhost:3000"}
+	r, err := os.Open(test.HTMLTestFilePath(t, "index.html"))
+	index, err := NewDocumentFromReader("index.html", r)
+	require.Nil(t, err)
+	req := NewHTMLRequest(index)
+	req.SetBasicAuth("foo", "bar")
+	dirPath, err := test.Rand()
+	require.Nil(t, err)
+	dest := fmt.Sprintf("%s/foo.pdf", dirPath)
+	err = c.Store(req, dest)
+	assert.Nil(t, err)
+	assert.FileExists(t, dest)
+	err = os.RemoveAll(dirPath)
+	assert.Nil(t, err)
+}
+
 func TestHTMLComplete(t *testing.T) {
 	c := &Client{Hostname: "http://localhost:3000"}
 	index, err := NewDocumentFromPath("index.html", test.HTMLTestFilePath(t, "index.html"))


### PR DESCRIPTION

**Summary**
- Add `NewDocumentFromReader` which accepts io.Reader interface for more generic use cases. e.g. buffers, HTTP reader, etc. 